### PR TITLE
Expose reference to underlying native BottomSheetDialog, add example sheet above Tab Bar (Google Maps style).

### DIFF
--- a/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/ViewModels/ShowCaseViewModel.cs
+++ b/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/ViewModels/ShowCaseViewModel.cs
@@ -117,6 +117,9 @@ public sealed partial class ShowCaseViewModel : ObservableObject, IConfirmNaviga
     [ObservableProperty]
     private bool _isDraggable = true;
 
+    [ObservableProperty]
+    private bool _aboveTabBar = false;
+
     [RelayCommand]
     private void OpenShowcase()
     {

--- a/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/Views/ShowCasePage.xaml
+++ b/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/Views/ShowCasePage.xaml
@@ -19,6 +19,16 @@
                 Command="{Binding OpenNonModalShowcaseCommand}"
                 HorizontalOptions="Center"
                 Text="Open non-modal showcase" />
+            <HorizontalStackLayout
+                HorizontalOptions="Start">
+                <CheckBox
+                    IsChecked="{Binding AboveTabBar, Mode=TwoWay}"
+                    CheckedChanged="CheckBox_CheckedChanged"
+                    VerticalOptions="Center" />
+                <Label
+                    Text="Show non-modal sheet above tab bar (Android only)"
+                    VerticalOptions="Center"/>
+            </HorizontalStackLayout>
             <Button
                 Command="{Binding OpenShowcasePageAsBottomSheetCommand}"
                 HorizontalOptions="Center"
@@ -193,6 +203,7 @@
                 IsOpen="{Binding IsNonModalOpen}"
                 ShowHeader="{Binding ShowHeader}"
                 States="Peek,Medium,Large"
+                Opened="NonModalBottomSheetNonEdgeToEdge_Opened"
                 WindowBackgroundColor="{Binding WindowBackgroundColor, Mode=TwoWay}">
                 <bottomsheet:BottomSheet.Header>
                     <bottomsheet:BottomSheetHeader

--- a/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/Views/ShowCasePage.xaml.cs
+++ b/sample/Plugin.Maui.BottomSheet.Sample/Plugin.Maui.BottomSheet.Sample/Views/ShowCasePage.xaml.cs
@@ -1,5 +1,11 @@
 #if ANDROID
 using AAndroid = Microsoft.Maui.Controls.PlatformConfiguration.Android;
+using AndroidView = Android.Views.View;
+using Android.Graphics.Drawables;
+using AndroidX.AppCompat.App;
+using AndroidX.Core.View;
+using Microsoft.Maui.Platform;
+using Plugin.Maui.BottomSheet.Platform.Android;
 using Plugin.Maui.BottomSheet.PlatformConfiguration.AndroidSpecific;
 #endif
 
@@ -19,4 +25,71 @@ public partial class ShowCasePage : ContentPage
         NonModalBottomSheetNonEdgeToEdge.On<AAndroid>().SetHalfExpandedRatio(0.2f);
 #endif
     }
+
+    /// <summary>
+    /// Toggles the Shell tab bar visibility.
+    /// </summary>
+    private void CheckBox_CheckedChanged(object sender, CheckedChangedEventArgs e)
+    {
+        if (sender is CheckBox checkbox)
+        {
+            Shell.SetTabBarIsVisible(this, checkbox.IsChecked);
+        }
+    }
+
+    /// <summary>
+    /// If <see cref="ShowCaseViewModel.AboveTabBar"/> is set, shows the non-modal bottom sheet
+    /// with an offset such that it is above the TabBar and not in-front of it.
+    /// </summary>
+    private void NonModalBottomSheetNonEdgeToEdge_Opened(object sender, EventArgs e)
+    {
+#if ANDROID
+        if (BindingContext is ShowCaseViewModel showCaseViewModel &&
+            showCaseViewModel.AboveTabBar &&
+            sender is BottomSheet bottomSheet &&
+            bottomSheet.Handler?.PlatformView is MauiBottomSheet platformView &&
+            platformView.Dialog is AppCompatDialog dialog &&
+            dialog.Window?.DecorView is AndroidView decorView)
+        {
+            // Show the bottom sheet above the tab bar.
+            ViewCompat.SetOnApplyWindowInsetsListener(decorView, new CustomWindowInsetsListener(dialog));
+        }
+#endif
+    }
+
+#if ANDROID
+    /// <summary>
+    /// Custom class that shows the bottom sheet vertically above the tab bar.
+    /// </summary>
+    internal class CustomWindowInsetsListener : Java.Lang.Object, IOnApplyWindowInsetsListener
+    {
+        private readonly AppCompatDialog _bottomSheetDialog;
+
+        public CustomWindowInsetsListener(AppCompatDialog bottomSheetDialog)
+        {
+            _bottomSheetDialog = bottomSheetDialog;
+        }
+
+        WindowInsetsCompat IOnApplyWindowInsetsListener.OnApplyWindowInsets(AndroidView v, WindowInsetsCompat insets)
+        {
+            if (_bottomSheetDialog.Context.Resources is Android.Content.Res.Resources resources)
+            {
+                int resourceId = resources.GetIdentifier("design_bottom_navigation_height", "dimen", _bottomSheetDialog.Context.PackageName);
+                if (resourceId > 0)
+                {
+                    int height = resources.GetDimensionPixelSize(resourceId);
+                    _bottomSheetDialog.Window?.SetBackgroundDrawable(
+                        new InsetDrawable(
+                            drawable: new ColorDrawable(Colors.Transparent.ToPlatform()),
+                            insetLeft: 0,
+                            insetTop: 0,
+                            insetRight: 0,
+                            insetBottom: height));
+                }
+            }
+
+            return insets;
+        }
+    }
+#endif
 }

--- a/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/Android/BottomSheet.android.cs
+++ b/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/Android/BottomSheet.android.cs
@@ -159,6 +159,11 @@ internal sealed class BottomSheet : IDisposable
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the BottomSheetDialog.
+    /// </summary>
+    public AndroidX.AppCompat.App.AppCompatDialog? Dialog => _bottomSheetDialog;
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/Android/MauiBottomSheet.android.cs
+++ b/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/Android/MauiBottomSheet.android.cs
@@ -11,7 +11,7 @@ namespace Plugin.Maui.BottomSheet.Platform.Android;
 using Microsoft.Maui.Platform;
 
 /// <inheritdoc />
-internal sealed class MauiBottomSheet : AndroidView
+public sealed class MauiBottomSheet : AndroidView
 {
     private readonly IMauiContext _mauiContext;
     private readonly BottomSheet _bottomSheet;
@@ -36,6 +36,11 @@ internal sealed class MauiBottomSheet : AndroidView
     /// Gets a value indicating whether the bottom sheet is open.
     /// </summary>
     public bool IsOpen => _bottomSheet.IsShowing;
+
+    /// <summary>
+    /// Gets a reference to the Android BottomSheetDialog if the bottom sheet is open.
+    /// </summary>
+    public AndroidX.AppCompat.App.AppCompatDialog? Dialog => _bottomSheet.Dialog;
 
     /// <summary>
     /// Set allowed bottom sheet states.

--- a/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/MaciOS/MauiBottomSheet.macios.cs
+++ b/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Platform/MaciOS/MauiBottomSheet.macios.cs
@@ -9,7 +9,7 @@ using AsyncAwaitBestPractices;
 using UIKit;
 
 /// <inheritdoc />
-internal sealed class MauiBottomSheet : UIView
+public sealed class MauiBottomSheet : UIView
 {
     private readonly IMauiContext _mauiContext;
     private readonly BottomSheet _bottomSheet;


### PR DESCRIPTION
# 🚀 Pull Request Template

## Description
Expose reference to underlying native BottomSheetDialog, add example sheet above Tab Bar (Google Maps style).

Changes:
1. Plugin.Maui.BottomSheet:
- Expose MauiBottomSheet, and add a method to get the underlying dialog reference. This is required because there isn't any Android API to get a reference to a shown dialog if you don't already have a reference to it.

2. Sample:
- Add checkbox which can toggle if the non-modal bottom sheet will be shown above or in front of the tab bar.
- On Opened, add the insets listener which updates the background drawable.

Fixes #149 

## Type of Change

Please delete options that are not relevant.

- [x] ✨ New feature
## Checklist

- [ ] I have made corresponding changes to the documentation - No doc changes
- [x] My changes do not introduce new linter warnings
- [x] My code follows the style guidelines of this project

## Screenshots (if applicable)

![AboveTabBar](https://github.com/user-attachments/assets/ca4cc0a9-33ad-4952-aaf7-46f6ceb4a642)

