### PR TITLE
[iOS] [macOS] Fix casing inconsistency in project references

### DIFF
--- a/src/Plugin.BottomSheet.iOSMacCatalyst/Plugin.BottomSheet.iOSMacCatalyst.csproj
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/Plugin.BottomSheet.iOSMacCatalyst.csproj
@@ -8,6 +8,9 @@
         </TargetFrameworks>
 
         <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+
+        <AssemblyName>Plugin.BottomSheet.iOSMacCatalyst</AssemblyName>
+        <RootNamespace>Plugin.BottomSheet.iOSMacCatalyst</RootNamespace>
     </PropertyGroup>
 	
     <ItemGroup>

--- a/src/Plugin.BottomSheet/Plugin.BottomSheet.csproj
+++ b/src/Plugin.BottomSheet/Plugin.BottomSheet.csproj
@@ -11,7 +11,7 @@
 			<_Parameter1>Plugin.BottomSheet.Android</_Parameter1>
 		</AssemblyAttribute>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-            <_Parameter1>Plugin.BottomSheet.IOSMacCatalyst</_Parameter1>
+            <_Parameter1>Plugin.BottomSheet.iOSMacCatalyst</_Parameter1>
         </AssemblyAttribute>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>Plugin.Maui.BottomSheet</_Parameter1>

--- a/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet.csproj
+++ b/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet.csproj
@@ -68,7 +68,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework.EndsWith('ios')) or $(TargetFramework.EndsWith('maccatalyst'))">
-        <ProjectReference Include="..\Plugin.BottomSheet.IOSMacCatalyst\Plugin.BottomSheet.IOSMacCatalyst.csproj" />
+        <ProjectReference Include="..\Plugin.BottomSheet.iOSMacCatalyst\Plugin.BottomSheet.iOSMacCatalyst.csproj" />
     </ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('windows'))">


### PR DESCRIPTION
# 🚀 Pull Request Template

## Description

This pull request fixes casing inconsistencies in project references. It also adds `AssemblyName` and `RootNamespace` configurations to the iOSMacCatalyst project, ensuring consistency and reducing potential build issues.

Fixes #190