### PR TITLE
[BUG] [iOS] [Android] [macOS] [Windows] [Navigation] Find correct Page parent for Shell and non Shell Apps

### DIFF
--- a/src/Plugin.Maui.BottomSheet/ElementExtensions.cs
+++ b/src/Plugin.Maui.BottomSheet/ElementExtensions.cs
@@ -16,17 +16,18 @@ internal static class ElementExtensions
         Page? page = null;
         Element? parent = element;
 
-        if (element is IPageContainer<Page> pageContainer)
+        if (parent is Shell || parent is NavigationPage)
         {
-            page = pageContainer.CurrentPage;
+            page = GetCurrentPageFromNavigation(parent);
         }
         else if (parent is FlyoutPage flyoutPage)
         {
             page = flyoutPage.IsPresented ? flyoutPage.Flyout : flyoutPage.Detail;
 
-            if (page is IPageContainer<Page> container)
+            if (page is Shell
+                || page is NavigationPage)
             {
-                page = container.CurrentPage;
+                page = GetCurrentPageFromNavigation(page);
             }
         }
         else
@@ -44,5 +45,26 @@ internal static class ElementExtensions
         }
 
         return page;
+    }
+
+    /// <summary>
+    /// Retrieves the currently active page from the navigation stack of the specified element.
+    /// This method determines the top page from either the navigation stack or the modal stack.
+    /// </summary>
+    /// <param name="element">The element whose navigation stack is to be inspected.</param>
+    /// <returns>The currently active page if found, otherwise null.</returns>
+    private static Page GetCurrentPageFromNavigation(Element element)
+    {
+        INavigation navigation;
+        if (element is Shell shell)
+        {
+            navigation = shell.Navigation;
+        }
+        else
+        {
+            navigation = ((NavigationPage)element).Navigation;
+        }
+
+        return navigation.ModalStack.Count == 0 ? navigation.NavigationStack[^1] : navigation.ModalStack[^1];
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request Template

## Description

When presenting a modal page and trying to present a BottomSheet from there, my app crashes on iOS. Without error or stack trace. Just gone. The reason for that was that no window could be found to present the sheet.

I added a little logic to traverse the view tree, to make sure a window is available to present the sheet.

## Type of Change

Please delete options that are not relevant.

- [ x ] 🐛 Bug fix
- [ ] ✨ New feature
- [ x ] 🔨 Refactoring
- [ ] 📝 Documentation update
- [ ] ✅ Test addition/fix
- [ ] 🚀 Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔧 Build/CI changes

## Checklist

- [ ] I have made corresponding changes to the documentation
- [ x ] My changes do not introduce new linter warnings
- [ x ] My code follows the style guidelines of this project
