### PR TITLE
[BUG] [Android] [iOS] Re-opening BottomSheet in Peek may not calculate hight

### DIFF
--- a/src/Plugin.Maui.BottomSheet/PeekViewExtension.cs
+++ b/src/Plugin.Maui.BottomSheet/PeekViewExtension.cs
@@ -123,6 +123,8 @@ public sealed class PeekViewExtension : IMarkupExtension<double>
     /// <param name="e">An <see cref="EventArgs"/> instance containing the event data.</param>
     private void SheetOnClosing(object? sender, EventArgs e)
     {
+        _view = null;
+
         if (_bottomSheet?.TryGetTarget(out BottomSheet? sheet) == true)
         {
             sheet.LayoutChanged -= SheetOnLayoutChanged;


### PR DESCRIPTION
fix #206 