### PR TITLE
[iOS] Fix gesture recognizer attachment logic in BottomSheet to ensure proper dim view handling

### DIFF
--- a/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
@@ -322,14 +322,15 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         ApplyBackgroundColor();
         ApplyWindowBackgroundColor();
 
-        if (PresentationController?.ContainerView.Subviews.FirstOrDefault()?.GestureRecognizers is UIGestureRecognizer[] gestureRecognizers)
+        if (PresentationController?.ContainerView.Subviews.FirstOrDefault() is UIView view
+            && view.GestureRecognizers is UIGestureRecognizer[] gestureRecognizers)
         {
             if (gestureRecognizers.FirstOrDefault() is UITapGestureRecognizer defaultGestureRecognizer)
             {
                 defaultGestureRecognizer.Enabled = false;
             }
 
-            PresentationController.ContainerView.AddGestureRecognizer(_dimViewGestureRecognizer);
+            view.AddGestureRecognizer(_dimViewGestureRecognizer);
         }
     }
 


### PR DESCRIPTION
There was an issue in some layouts where the `_dimViewGestureRecognizer` was not attached to the `UIDimmingView`.

This PR ensures that the gesture recognizer is attached to the dimming view.