### PR TITLE
Fix iOS overlay issue for modal bottomsheet with FitToContent activated.

### DIFF
--- a/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
@@ -182,8 +182,9 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
 
             if (SheetPresentationController is not null)
             {
-                // Actually bug in UIKit. Custom detent can't be undimmed. Submit a bug?.
-                SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal ? UISheetPresentationControllerDetentIdentifier.Unknown : States.Last().ToPlatformState();
+                SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal
+                    ? UISheetPresentationControllerDetentIdentifier.Unknown
+                    : UISheetPresentationControllerDetentIdentifier.Large;
             }
 
             ApplyWindowBackgroundColor();
@@ -274,11 +275,25 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         {
             _sizeMode = value;
 
-            UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent ? [_contentDetent] : SheetPresentationController?.Detents ?? [_largeDetent];
+            // When non-modal + FitToContent, always include the standard .large detent alongside
+            // the custom content detent. UIKit requires LargestUndimmedDetentIdentifier to match
+            // an entry in the Detents list — without .large present, the setting is silently
+            // ignored and the dim overlay remains even with IsModal=False.
+            UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent
+                ? (_isModal ? [_contentDetent] : [_contentDetent, _largeDetent])
+                : SheetPresentationController?.Detents ?? [_largeDetent];
 
             SheetPresentationController?.AnimateChanges(() =>
             {
                 SheetPresentationController.Detents = detents;
+
+                // _largeDetent is added as a sentinel only; reset the selected detent to the
+                // content detent so the sheet does not open at full height.
+                // Unknown causes UIKit to fall back to the first detent (_contentDetent).
+                if (_sizeMode == BottomSheetSizeMode.FitToContent && !_isModal)
+                {
+                    SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+                }
             });
         }
     }
@@ -318,6 +333,28 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     public override void ViewWillAppear(bool animated)
     {
         base.ViewWillAppear(animated);
+
+        if (SheetPresentationController is UISheetPresentationController spc && !_isModal)
+        {
+            // SheetPresentationController may have been null when SetSizeMode/SetStates were
+            // called (before presentation), so the detents may not yet be configured correctly.
+            // ViewWillAppear is the earliest point where the SPC is guaranteed non-null.
+            if (_sizeMode == BottomSheetSizeMode.FitToContent)
+            {
+                // UIKit requires LargestUndimmedDetentIdentifier to reference a detent that
+                // exists in the Detents array. FitToContent uses a custom detent only, so
+                // .large is absent and UIKit silently ignores the setting. Add _largeDetent
+                // as a sentinel entry so the identifier is recognised.
+                spc.Detents = [_contentDetent, _largeDetent];
+
+                // _largeDetent is a sentinel only; reset the selection to the content detent
+                // so the sheet opens at FitToContent height, not full-screen.
+                // Unknown causes UIKit to fall back to the first detent (_contentDetent).
+                spc.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+            }
+
+            spc.LargestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Large;
+        }
 
         ApplyBackgroundColor();
         ApplyWindowBackgroundColor();
@@ -477,6 +514,10 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         }
 
         SheetPresentationController.PrefersEdgeAttachedInCompactHeight = true;
+
+        SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal
+            ? UISheetPresentationControllerDetentIdentifier.Unknown
+            : UISheetPresentationControllerDetentIdentifier.Large;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
When opening a BottomSheet configured with IsModal=False and SizeMode=FitToContent (via IBottomSheetNavigationService.NavigateToAsync()), iOS always renders a dark semi-transparent overlay behind the sheet, and the underlying page content is not interactive.

- On Android the behaviour is correct: no overlay, underlying content remains tappable.
- On iOS, the overlay persists regardless of IsModal=False and WindowBackgroundColor=Transparent.

Note: The existing inline-XAML showcase (States="Peek,Medium,Large") works correctly because it uses standard detents. The bug is specific to navigation-based sheets that use SizeMode=FitToContent (custom detent).

**Environment**
Plugin version: 10.0.7
Target framework: net10.0-ios
Tested on: iPhone (iOS 17/18/26)

### Steps to Reproduce

A minimal repro sample is available here : [sample](https://github.com/slouge/Maui.BottomSheet/tree/repro-ios-non-modal-overlay-sample) based on your existing sample including a new page to test the behavior and the changes below :

**Style (Styles.xaml):**

```xml
<Style x:Key="BaseBottomSheetStyle" TargetType="bottomsheet:BottomSheet">
    <Setter Property="SizeMode" Value="FitToContent" />
    <Setter Property="IsCancelable" Value="True" />
    <Setter Property="IsDraggable" Value="True" />
    <Setter Property="IsModal" Value="True" />
</Style>

<Style x:Key="NoOverlayBottomSheetStyle"
       TargetType="bottomsheet:BottomSheet"
       BasedOn="{StaticResource BaseBottomSheetStyle}">
    <Setter Property="WindowBackgroundColor" Value="Transparent" />
    <Setter Property="IsModal" Value="False" />
</Style>
```

**BottomSheet XAML:**

```xml
<bottomsheet:BottomSheet
    xmlns:bottomsheet="http://pluginmauibottomsheet.com"
    x:Class="MyApp.MyBottomSheet"
    Style="{StaticResource NoOverlayBottomSheetStyle}">
    <bottomsheet:BottomSheetContent>
        <Label Text="Hello" Margin="20" />
    </bottomsheet:BottomSheetContent>
</bottomsheet:BottomSheet>
```

**Opening:**

```csharp
await _bottomSheetNavigationService.NavigateToAsync("MyBottomSheet");
```

### Affected platforms

iOS

### Did you find any workaround?

No direct and easy workaround, plugin code change required.

### Root Cause Analysis
There are two combined issues in Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs:

**Issue 1 : LargestUndimmedDetentIdentifier is never applied**
The IsModal setter guards the assignment behind if (SheetPresentationController is not null), but IsModal is set from XAML/styles before the sheet is presented at which point SheetPresentationController is always null. The block is silently skipped every time.

```csharp
// IsModal setter — current code
if (SheetPresentationController is not null)
{
    // ↑ SheetPresentationController is null here (sheet not yet presented)
    // This block never executes when IsModal is set from XAML
    SheetPresentationController.LargestUndimmedDetentIdentifier = ...;
}
```
InitSheetPresentationController() is called just before PresentViewControllerAsync (when the SPC becomes available), but it does not apply LargestUndimmedDetentIdentifier.

**Issue 2 : Wrong identifier when using SizeMode=FitToContent**
Even if the assignment were reached, States.Last().ToPlatformState() returns UISheetPresentationControllerDetentIdentifier.Unknown for the Peek state used by custom detents. Unknown means "dim everything" — the opposite of the intended behaviour.

```csharp
// Current (wrong) code
SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal
    ? UISheetPresentationControllerDetentIdentifier.Unknown
    : States.Last().ToPlatformState();  // ← returns Unknown for FitToContent
```

**Issue 3 : UIKit requires the identifier to match an existing detent**
LargestUndimmedDetentIdentifier = .large only works when .large is present in SheetPresentationController.Detents. With SizeMode=FitToContent, the detents array contains only a custom detent. UIKit silently ignores an identifier that does not match any entry in the list, so even setting .large has no effect.


### Proposed Fix
All changes are in Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs.

**Fix 1 : Apply in ViewWillAppear (SPC guaranteed non-null)**
ViewWillAppear is the earliest point where SheetPresentationController is guaranteed available (before the presentation animation starts).

For FitToContent non-modal sheets, also inject _largeDetent into the detents array and reset SelectedDetentIdentifier so the sheet does not open at full height.

```csharp
public override void ViewWillAppear(bool animated)
{
    base.ViewWillAppear(animated);

    if (SheetPresentationController is UISheetPresentationController spc && !_isModal)
    {
        if (_sizeMode == BottomSheetSizeMode.FitToContent)
        {
            // UIKit requires LargestUndimmedDetentIdentifier to reference a detent that exists
            // in the Detents list. FitToContent only adds a custom detent, so .large is absent
            // and the setting is silently ignored. Add _largeDetent as a sentinel entry.
            spc.Detents = [_contentDetent, _largeDetent];

            // _largeDetent is now in the list but we do not want the sheet to open at full height.
            // Unknown causes UIKit to fall back to the first detent (_contentDetent = FitToContent).
            spc.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
        }

        spc.LargestUndimmedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Large;
    }

    ApplyBackgroundColor();
    ApplyWindowBackgroundColor();
    // ... rest unchanged
}
```

**Fix 2 : Correct identifier in IsModal setter and InitSheetPresentationController**
Use .Large unconditionally instead of States.Last().ToPlatformState():

```csharp
// IsModal setter
if (SheetPresentationController is not null)
{
    SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal
        ? UISheetPresentationControllerDetentIdentifier.Unknown
        : UISheetPresentationControllerDetentIdentifier.Large;
}

// InitSheetPresentationController
SheetPresentationController.PrefersEdgeAttachedInCompactHeight = true;
SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal
    ? UISheetPresentationControllerDetentIdentifier.Unknown
    : UISheetPresentationControllerDetentIdentifier.Large;
```

**Fix 3 : Include _largeDetent in SizeMode setter when non-modal**
So the detents are correct even if the SPC happens to be available at setup time:

```csharp
UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent
    ? (_isModal ? [_contentDetent] : [_contentDetent, _largeDetent])
    : SheetPresentationController?.Detents ?? [_largeDetent];
```

### Result After Fix
|  | Before | After  |
|-------|--------|---|
|iOS overlay	|Dark semi-transparent overlay ❌ |	No overlay ✅|
|Touch passthrough	|Page blocked ❌	|Page fully interactive ✅|
|Sheet height	|Correct (FitToContent) ✅|Correct (FitToContent) ✅|
|Android|	Correct ✅|	Unchanged ✅|
|Modal sheets	|Overlay present ✅	|Unchanged ✅|

Fixes #245 

## Type of Change

- [x] 🐛 Bug fix

## Checklist


- [x] I have made corresponding changes to the documentation
- [x] My changes do not introduce new linter warnings
- [x] My code follows the style guidelines of this project

## Screenshots (if applicable)

| Before | After |
|--------|-------|
|<img width="393" height="854" alt="593016884-156debf3-64fe-4376-9040-64d723466d3c (Petite)" src="https://github.com/user-attachments/assets/ffc19cc2-5f27-44a3-b622-df11004cbe8b" />|<img width="393" height="854" alt="593017179-8d1dec0a-aa89-4552-9d8f-7d65b64a1ae8 (Petite)" src="https://github.com/user-attachments/assets/ca354798-12c6-4783-ad4b-be07562222de" /><img width="393" height="854" alt="593017390-d2ea06fc-e1f0-4a62-a2be-a3f113704355 (Petite)" src="https://github.com/user-attachments/assets/0cf8916d-c4cf-4648-92b5-667a9b652465" />|

## Additional Context

Sample available on the branch present on my own fork (see issue description)
