### PR TITLE
Support custom-detent large sentinel on iOS and MacCatalyst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Desktop.ini
 .DS_Store
 
 **/artifacts/
+
+**/.junie/

--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ or
 > Mode `FitToContent` is not compatible with the `States` and `CurrentState` property. Do not mix these two properties.
 > Requires iOS 16+. On prior versions of iOS, the medium state will be used instead.
 
+> [!NOTE]
+> On iOS and MacCatalyst, custom-detent presentations such as `FitToContent` and peek-only sheets internally include a large detent sentinel so UIKit can keep non-modal sheets undimmed. If the user drags to that sentinel, the sheet automatically snaps back to the custom detent.
+
 ### 🎭 BottomSheet States
 
 | State    | Description                      |

--- a/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
@@ -28,8 +28,9 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     private BottomSheetContainerViewController? _containerViewController;
 
     private BottomSheetSizeMode _sizeMode;
-    private BottomSheetState[] _configuredStates = [BottomSheetState.Large];
-    private bool _isRestoringCustomDetent;
+    private bool _isRestoringOldState;
+    private ICollection<BottomSheetState> _states = [];
+    private bool _addedLargeDetentSentinelForCustomDetent;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BottomSheet"/> class.
@@ -180,12 +181,13 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         {
             _isModal = value;
 
+            RefreshDetents();
             _dimViewGestureRecognizer.Enabled = _isModal;
 
             if (SheetPresentationController is not null)
             {
-                // Actually bug in UIKit. Custom detent can't be undimmed. Submit a bug?.
-                SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal ? UISheetPresentationControllerDetentIdentifier.Unknown : States.Last().ToPlatformState();
+                // Actually bug in UIKit. Custom detent can't be undimmed. Submit a bug?
+                SheetPresentationController.LargestUndimmedDetentIdentifier = _isModal ? UISheetPresentationControllerDetentIdentifier.Unknown : LogicalStates.Last().ToPlatformState();
             }
 
             ApplyWindowBackgroundColor();
@@ -200,10 +202,15 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         get => SheetPresentationController?.SelectedDetentIdentifier.ToBottomSheetState() ?? BottomSheetState.Peek;
         set
         {
-            SheetPresentationController?.AnimateChanges(() =>
+            if (ValidateState(value, State))
             {
-                SheetPresentationController.SelectedDetentIdentifier = value.ToPlatformState();
-            });
+                SheetPresentationController?.AnimateChanges(() =>
+                {
+                    SheetPresentationController.SelectedDetentIdentifier = value.ToPlatformState();
+
+                    _bottomSheetDelegate.CurrentState = State;
+                });
+            }
         }
     }
 
@@ -214,32 +221,30 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     {
         get
         {
+            return _states;
+        }
+
+        set
+        {
+            _states = value;
+            LogicalStates = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the collection of states that define the possible configurations
+    /// of the bottom sheet at different detent levels, such as Peek, Medium, and Large.
+    /// </summary>
+    public ICollection<BottomSheetState> LogicalStates
+    {
+        get
+        {
             return SheetPresentationController is null ? [] : SheetPresentationController.Detents.ToBottomSheetStates();
         }
 
         set
         {
-            _configuredStates = value.ToArray();
-
-            SheetPresentationController?.AnimateChanges(() =>
-            {
-                UISheetPresentationControllerDetent[] detents = _configuredStates
-                    .Select(ToPlatformDetent)
-                    .ToArray();
-
-                if (ShouldUseLargeDetentSentinelForPeekState())
-                {
-                    // UIKit cannot undim a custom-only detent, so keep a native large detent as the undimmed sentinel.
-                    detents = detents.Append(_largeDetent).ToArray();
-                }
-
-                SheetPresentationController.Detents = detents;
-
-                if (ShouldLockToCustomDetent())
-                {
-                    SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
-                }
-            });
+            SetDetents(value);
         }
     }
 
@@ -279,16 +284,14 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         {
             _sizeMode = value;
 
-            UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent ? [_contentDetent, _largeDetent] : SheetPresentationController?.Detents ?? [_largeDetent];
+            List<UISheetPresentationControllerDetent> detents = _sizeMode == BottomSheetSizeMode.FitToContent ? [_contentDetent] : SheetPresentationController?.Detents.ToList() ?? [_largeDetent];
+            AddLargeDetentIfNecessary(detents);
 
             SheetPresentationController?.AnimateChanges(() =>
             {
-                SheetPresentationController.Detents = detents;
-
-                if (ShouldLockToCustomDetent())
-                {
-                    SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
-                }
+                SheetPresentationController.Detents = detents.ToArray();
+                SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+                _bottomSheetDelegate.CurrentState = State;
             });
         }
     }
@@ -566,10 +569,8 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     /// <param name="e">The event arguments.</param>
     private void BottomSheetDelegateOnStateChanged(object? sender, BottomSheetStateChangedEventArgs e)
     {
-        if (e.NewState == BottomSheetState.Large
-            && ShouldLockToCustomDetent())
+        if (ValidateState(e.NewState, e.OldState) == false)
         {
-            RestoreSelectedCustomDetent();
             return;
         }
 
@@ -580,61 +581,82 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     }
 
     /// <summary>
-    /// Converts a logical bottom sheet state to the native detent instance used by UIKit.
+    /// Ensures a large detent is added to the provided list of detents if necessary based on the current
+    /// configuration of the bottom sheet. This is required to accommodate scenarios where UIKit requires
+    /// a native large detent as an undimmed sentinel, especially when using custom-only detents.
     /// </summary>
-    /// <param name="state">The logical bottom sheet state to convert.</param>
-    /// <returns>The native detent that represents the requested state.</returns>
-    private UISheetPresentationControllerDetent ToPlatformDetent(BottomSheetState state)
+    /// <param name="detents">A list of <see cref="UISheetPresentationControllerDetent"/> to potentially modify
+    /// by adding a large detent as a sentinel if required.</param>
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "Is validated.")]
+    private void AddLargeDetentIfNecessary(List<UISheetPresentationControllerDetent> detents)
     {
-        return state switch
-        {
-            BottomSheetState.Peek => _peekDetent,
-            BottomSheetState.Medium => _mediumDetent,
-            _ => _largeDetent,
-        };
-    }
-
-    /// <summary>
-    /// Determines whether the configured states rely on a single custom peek detent.
-    /// </summary>
-    /// <returns>True when the sheet should remain locked to the custom peek detent.</returns>
-    private bool ShouldUseLargeDetentSentinelForPeekState()
-    {
-        return _sizeMode == BottomSheetSizeMode.States
-            && _configuredStates.Length == 1
-            && _configuredStates[0] == BottomSheetState.Peek;
-    }
-
-    /// <summary>
-    /// Determines whether UIKit should be prevented from staying on the sentinel large detent.
-    /// </summary>
-    /// <returns>True when the current presentation uses a custom-only detent.</returns>
-    private bool ShouldLockToCustomDetent()
-    {
-        return _isRestoringCustomDetent == false
-            && (_sizeMode == BottomSheetSizeMode.FitToContent
-                || ShouldUseLargeDetentSentinelForPeekState());
-    }
-
-    /// <summary>
-    /// Restores the selected native detent to the custom detent after UIKit briefly selects the helper large detent.
-    /// </summary>
-    private void RestoreSelectedCustomDetent()
-    {
-        if (SheetPresentationController is null)
+        if (OperatingSystem.IsMacCatalyst()
+            || (OperatingSystem.IsIOS()
+                && OperatingSystem.IsIOSVersionAtLeast(16)))
         {
             return;
         }
 
-        try
+        _addedLargeDetentSentinelForCustomDetent = false;
+
+        bool isOnlyPeekState = _sizeMode == BottomSheetSizeMode.States
+           && detents.Count == 1
+           && detents[0].Identifier == PeekDetentId;
+
+        bool shouldAddLargeDetentSentinelForCustomDetent = IsModal == false
+           && (isOnlyPeekState
+               || _sizeMode == BottomSheetSizeMode.FitToContent);
+
+        if (!shouldAddLargeDetentSentinelForCustomDetent)
         {
-            _isRestoringCustomDetent = true;
-            SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+            return;
         }
-        finally
+
+        // UIKit cannot undim a custom-only detent, so keep a native large detent as the undimmed sentinel.
+        detents.Add(_largeDetent);
+
+        _addedLargeDetentSentinelForCustomDetent = true;
+    }
+
+    /// <summary>
+    /// Validates the transition between two <see cref="BottomSheetState"/> values, ensuring that the new state adheres to the component's constraints.
+    /// </summary>
+    /// <param name="newState">The new <see cref="BottomSheetState"/> to which the bottom sheet is attempting to transition.</param>
+    /// <param name="oldState">The previous <see cref="BottomSheetState"/> from which the bottom sheet is transitioning.</param>
+    /// <returns>
+    /// A boolean value indicating whether the transition to the new state is valid. Returns <c>true</c> if the transition is allowed, otherwise <c>false</c>.
+    /// </returns>
+    private bool ValidateState(BottomSheetState newState, BottomSheetState oldState)
+    {
+        // ReSharper disable once ReplaceWithSingleAssignment.True
+        bool isNewStateValid = true;
+
+        if (newState == BottomSheetState.Large
+            && _isRestoringOldState == false
+            && _addedLargeDetentSentinelForCustomDetent)
         {
-            _isRestoringCustomDetent = false;
+            isNewStateValid = false;
         }
+
+        if (isNewStateValid == false)
+        {
+            RestoreOldState(oldState);
+        }
+
+        return isNewStateValid;
+    }
+
+    /// <summary>
+    /// Restores the previous state of the bottom sheet to the specified <see cref="BottomSheetState"/> value.
+    /// This method sets the <see cref="State"/> property to the provided state and ensures that the
+    /// restoration process is tracked to prevent conflicts with other state changes.
+    /// </summary>
+    /// <param name="oldState">The previous <see cref="BottomSheetState"/> to restore.</param>
+    private void RestoreOldState(BottomSheetState oldState)
+    {
+        _isRestoringOldState = true;
+        State = oldState;
+        _isRestoringOldState = false;
     }
 
     /// <summary>
@@ -650,6 +672,54 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
                 this,
                 e,
                 nameof(Canceled));
+        }
+    }
+
+    /// <summary>
+    /// Configures the available states of the bottom sheet by setting its detents.
+    /// Each detent represents a predefined height or state that the bottom sheet can occupy.
+    /// </summary>
+    /// <param name="states">A collection of <see cref="BottomSheetState"/> values that define the possible states of the bottom sheet.</param>
+    private void SetDetents(ICollection<BottomSheetState> states)
+    {
+        SheetPresentationController?.AnimateChanges(() =>
+        {
+            List<UISheetPresentationControllerDetent> detents = states
+                .Select(x =>
+                {
+                    UISheetPresentationControllerDetent detent = x switch
+                    {
+                        BottomSheetState.Peek => _peekDetent,
+                        BottomSheetState.Medium => _mediumDetent,
+                        _ => _largeDetent,
+                    };
+
+                    return detent;
+                })
+                .ToList();
+
+            AddLargeDetentIfNecessary(detents);
+
+            SheetPresentationController.Detents = detents.ToArray();
+            SheetPresentationController.SelectedDetentIdentifier = State.ToPlatformState();
+        });
+    }
+
+    /// <summary>
+    /// Updates the detents of the <see cref="BottomSheet"/> based on the current size mode.
+    /// If the size mode is set to <see cref="BottomSheetSizeMode.States"/>, the available detents are updated
+    /// using the configured states in the <see cref="States"/> collection. For other modes, it resets
+    /// to the current size mode.
+    /// </summary>
+    private void RefreshDetents()
+    {
+        if (_sizeMode == BottomSheetSizeMode.States)
+        {
+            SetDetents(States);
+        }
+        else
+        {
+            SizeMode = _sizeMode;
         }
     }
 }

--- a/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheet.cs
@@ -28,6 +28,8 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     private BottomSheetContainerViewController? _containerViewController;
 
     private BottomSheetSizeMode _sizeMode;
+    private BottomSheetState[] _configuredStates = [BottomSheetState.Large];
+    private bool _isRestoringCustomDetent;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BottomSheet"/> class.
@@ -217,23 +219,26 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
 
         set
         {
+            _configuredStates = value.ToArray();
+
             SheetPresentationController?.AnimateChanges(() =>
             {
-                UISheetPresentationControllerDetent[] detents = value
-                    .Select(x =>
-                    {
-                        UISheetPresentationControllerDetent detent = x switch
-                        {
-                            BottomSheetState.Peek => _peekDetent,
-                            BottomSheetState.Medium => _mediumDetent,
-                            _ => _largeDetent,
-                        };
-
-                        return detent;
-                    })
+                UISheetPresentationControllerDetent[] detents = _configuredStates
+                    .Select(ToPlatformDetent)
                     .ToArray();
 
+                if (ShouldUseLargeDetentSentinelForPeekState())
+                {
+                    // UIKit cannot undim a custom-only detent, so keep a native large detent as the undimmed sentinel.
+                    detents = detents.Append(_largeDetent).ToArray();
+                }
+
                 SheetPresentationController.Detents = detents;
+
+                if (ShouldLockToCustomDetent())
+                {
+                    SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+                }
             });
         }
     }
@@ -274,11 +279,16 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
         {
             _sizeMode = value;
 
-            UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent ? [_contentDetent] : SheetPresentationController?.Detents ?? [_largeDetent];
+            UISheetPresentationControllerDetent[] detents = _sizeMode == BottomSheetSizeMode.FitToContent ? [_contentDetent, _largeDetent] : SheetPresentationController?.Detents ?? [_largeDetent];
 
             SheetPresentationController?.AnimateChanges(() =>
             {
                 SheetPresentationController.Detents = detents;
+
+                if (ShouldLockToCustomDetent())
+                {
+                    SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+                }
             });
         }
     }
@@ -556,10 +566,75 @@ public sealed class BottomSheet : UINavigationController, IEnumerable<UIView>
     /// <param name="e">The event arguments.</param>
     private void BottomSheetDelegateOnStateChanged(object? sender, BottomSheetStateChangedEventArgs e)
     {
+        if (e.NewState == BottomSheetState.Large
+            && ShouldLockToCustomDetent())
+        {
+            RestoreSelectedCustomDetent();
+            return;
+        }
+
         _eventManager.RaiseEvent(
             this,
             e,
             nameof(StateChanged));
+    }
+
+    /// <summary>
+    /// Converts a logical bottom sheet state to the native detent instance used by UIKit.
+    /// </summary>
+    /// <param name="state">The logical bottom sheet state to convert.</param>
+    /// <returns>The native detent that represents the requested state.</returns>
+    private UISheetPresentationControllerDetent ToPlatformDetent(BottomSheetState state)
+    {
+        return state switch
+        {
+            BottomSheetState.Peek => _peekDetent,
+            BottomSheetState.Medium => _mediumDetent,
+            _ => _largeDetent,
+        };
+    }
+
+    /// <summary>
+    /// Determines whether the configured states rely on a single custom peek detent.
+    /// </summary>
+    /// <returns>True when the sheet should remain locked to the custom peek detent.</returns>
+    private bool ShouldUseLargeDetentSentinelForPeekState()
+    {
+        return _sizeMode == BottomSheetSizeMode.States
+            && _configuredStates.Length == 1
+            && _configuredStates[0] == BottomSheetState.Peek;
+    }
+
+    /// <summary>
+    /// Determines whether UIKit should be prevented from staying on the sentinel large detent.
+    /// </summary>
+    /// <returns>True when the current presentation uses a custom-only detent.</returns>
+    private bool ShouldLockToCustomDetent()
+    {
+        return _isRestoringCustomDetent == false
+            && (_sizeMode == BottomSheetSizeMode.FitToContent
+                || ShouldUseLargeDetentSentinelForPeekState());
+    }
+
+    /// <summary>
+    /// Restores the selected native detent to the custom detent after UIKit briefly selects the helper large detent.
+    /// </summary>
+    private void RestoreSelectedCustomDetent()
+    {
+        if (SheetPresentationController is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _isRestoringCustomDetent = true;
+            SheetPresentationController.SelectedDetentIdentifier = UISheetPresentationControllerDetentIdentifier.Unknown;
+        }
+        finally
+        {
+            _isRestoringCustomDetent = false;
+        }
     }
 
     /// <summary>

--- a/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheetDelegate.cs
+++ b/src/Plugin.BottomSheet.iOSMacCatalyst/BottomSheetDelegate.cs
@@ -29,6 +29,11 @@ internal sealed class BottomSheetDelegate : UISheetPresentationControllerDelegat
     }
 
     /// <summary>
+    /// Gets or sets current state of the bottom sheet, indicating its level of expansion or visibility.
+    /// </summary>
+    internal BottomSheetState CurrentState { get; set; }
+
+    /// <summary>
     /// Determines whether the presentation controller should dismiss when touched outside or swiped.
     /// Note: DidAttemptToDismiss is only called for swipe dismissal, while ShouldDismiss handles background taps and swipes.
     /// </summary>
@@ -69,7 +74,7 @@ internal sealed class BottomSheetDelegate : UISheetPresentationControllerDelegat
 
         _eventManager.RaiseEvent(
             sheetPresentationController,
-            new BottomSheetStateChangedEventArgs(state, state),
+            new BottomSheetStateChangedEventArgs(CurrentState, state),
             nameof(StateChanged));
     }
 }

--- a/src/Plugin.Maui.BottomSheet/Platform/MaciOS/MauiBottomSheet.macios.cs
+++ b/src/Plugin.Maui.BottomSheet/Platform/MaciOS/MauiBottomSheet.macios.cs
@@ -135,15 +135,22 @@ public sealed class MauiBottomSheet : UIView, IEnumerable<UIView>, IReloadHandle
         _bottomSheet.FrameChanged += BottomSheetOnFrameChanged;
         _bottomSheet.LayoutChanged += BottomSheetOnLayoutChanged;
 
-        SetStates();
+        if (_virtualView.SizeMode == BottomSheetSizeMode.States)
+        {
+            SetStates();
+            SetCurrentState();
+        }
+        else
+        {
+            SetSizeMode();
+        }
+
         SetIsCancelable();
-        SetCurrentState();
 
         SetWindowBackgroundColor();
         SetBottomSheetBackgroundColor();
         SetIsModal();
         SetCornerRadius();
-        SetSizeMode();
 
         UIView view = _virtualView.ContainerView.ToPlatform(_mauiContext);
         view.UpdateAutomationId(_virtualView);

--- a/tests/Unit/MAUI/Plugin.BottomSheet.Tests.Maui.Unit.Application/Tests/BottomSheetTests.cs
+++ b/tests/Unit/MAUI/Plugin.BottomSheet.Tests.Maui.Unit.Application/Tests/BottomSheetTests.cs
@@ -1,4 +1,5 @@
 using System.Windows.Input;
+using Microsoft.Maui.Platform;
 using NSubstitute;
 using Plugin.Maui.BottomSheet;
 using Plugin.Maui.BottomSheet.PlatformConfiguration.AndroidSpecific;
@@ -542,4 +543,177 @@ public class BottomSheetTests : BaseTest<Mocks.EmptyContentPage, Plugin.Maui.Bot
         Assert.NotEqual(BottomSheetState.Medium, View.CurrentState);
         Assert.Equal(BottomSheetState.Large, View.CurrentState);
     }
+
+    #if IOS || MACCATALYST
+    [UIFact]
+    public async Task NonModalSheet_OnlyPeekState_LargeState_IsAdded()
+    {
+        View.IsModal = false;
+        View.States = [BottomSheetState.Peek];
+        View.PeekHeight = 300;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Peek);
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+    
+    [UIFact]
+    public async Task NonModalSheet_PeekStateWithMedium_LargeNotAdded()
+    {
+        View.IsModal = false;
+        View.States = [BottomSheetState.Peek, BottomSheetState.Medium];
+        View.PeekHeight = 300;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Peek);
+        Assert.DoesNotContain(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+    
+    [UIFact]
+    public async Task NonModalSheet_OnlyPeekState_PeekStateLocked()
+    {
+        View.IsModal = false;
+        View.States = [BottomSheetState.Peek];
+        View.PeekHeight = 300;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        mauiBottomSheet.State = BottomSheetState.Large;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        
+        Assert.Equal(BottomSheetState.Peek, mauiBottomSheet.State);
+    }
+    
+    [UIFact]
+    public async Task ModalSheet_OnlyPeekState_LargeState_IsNotAdded()
+    {
+        View.IsModal = true;
+        View.States = [BottomSheetState.Peek];
+        View.PeekHeight = 300;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Peek);
+        Assert.DoesNotContain(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+    
+    [UIFact]
+    public async Task NonModalSheet_FitToContent_LargeState_IsAdded()
+    {
+        View.IsModal = false;
+        View.SizeMode = BottomSheetSizeMode.FitToContent;
+        View.Content = new BottomSheetContent
+        {
+            Content = new VerticalStackLayout
+            {
+                new Border { HeightRequest = 250, WidthRequest = 250 }
+            }
+        };
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Peek);
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+
+    [UIFact]
+    public async Task NonModalSheet_FitToContent_ContentState_IsLocked()
+    {
+        View.IsModal = false;
+        View.SizeMode = BottomSheetSizeMode.FitToContent;
+        View.Content = new BottomSheetContent
+        {
+            Content = new VerticalStackLayout
+            {
+                new Border { HeightRequest = 250, WidthRequest = 250 }
+            }
+        };
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        mauiBottomSheet.State = BottomSheetState.Large;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        
+        Assert.Equal(BottomSheetState.Peek, mauiBottomSheet.State);
+    }
+        
+    [UIFact]
+    public async Task ModalSheet_FitToContent_LargeState_IsNotNotAdded()
+    {
+        View.IsModal = true;
+        View.SizeMode = BottomSheetSizeMode.FitToContent;
+        View.Content = new BottomSheetContent
+        {
+            Content = new VerticalStackLayout
+            {
+                new Border { HeightRequest = 250, WidthRequest = 250 }
+            }
+        };
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Contains(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Peek);
+        Assert.DoesNotContain(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+    
+    [UIFact]
+    public async Task NonModalSheet_PeekOnly_StatesChanged_CurrentStateRemained()
+    {
+        View.IsModal = false;
+        View.States = [BottomSheetState.Peek];
+        View.PeekHeight = 200;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        View.States = [BottomSheetState.Peek, BottomSheetState.Medium];
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Equal(BottomSheetState.Peek, mauiBottomSheet.State);
+        Assert.Equal(mauiBottomSheet.LogicalStates.Count, View.States.Count);
+        Assert.DoesNotContain(mauiBottomSheet.LogicalStates, x => x == BottomSheetState.Large);
+    }
+    
+    [UIFact]
+    public async Task NonModalSheet_PeekOnly_StatesChanged_PeekNotLocked()
+    {
+        View.IsModal = false;
+        View.States = [BottomSheetState.Peek];
+        View.PeekHeight = 200;
+        View.IsOpen = true;
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        View.States = [BottomSheetState.Peek, BottomSheetState.Medium];
+        View.CurrentState = BottomSheetState.Medium;
+        iOSMacCatalyst.BottomSheet mauiBottomSheet = ((Plugin.Maui.BottomSheet.Platform.MaciOS.MauiBottomSheet)View.ToPlatform(View.Handler!.MauiContext!)).BottomSheet!;
+        
+        Assert.Equal(BottomSheetState.Medium, mauiBottomSheet.State);
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
- Ports the custom-detent large sentinel behavior from the vendored HueDynamic copy.
- Follows the maintainer approach discussed in lucacivale/Maui.BottomSheet#246: keep a native large detent available for UIKit while selecting the custom detent with Unknown.
- Restores transient Large selections back to the custom detent for FitToContent and peek-only custom-detent sheets.
- Documents the iOS/MacCatalyst sentinel behavior in the README.

## Validation
These were run sequentially from the parent workspace path to use the installed .NET 10.0.301 SDK because this checkout's global.json pins 10.0.100 with rollForward disabled:

```powershell
dotnet build Maui.BottomSheet-fork\src\Plugin.BottomSheet.iOSMacCatalyst\Plugin.BottomSheet.iOSMacCatalyst.csproj -f net10.0-ios
dotnet build Maui.BottomSheet-fork\src\Plugin.BottomSheet.iOSMacCatalyst\Plugin.BottomSheet.iOSMacCatalyst.csproj -f net10.0-maccatalyst
dotnet build Maui.BottomSheet-fork\src\Plugin.Maui.BottomSheet\Plugin.Maui.BottomSheet.csproj -f net10.0-ios
dotnet build Maui.BottomSheet-fork\src\Plugin.Maui.BottomSheet\Plugin.Maui.BottomSheet.csproj -f net10.0-maccatalyst
```

All completed with 0 warnings and 0 errors.
## Type of Change

Please delete options that are not relevant.

- [X] 🐛 Bug fix
- [X.. ish] ✨ New feature
